### PR TITLE
fix(docker): don't use deprecated kwarg in json.loads

### DIFF
--- a/rcds/challenge/docker.py
+++ b/rcds/challenge/docker.py
@@ -200,7 +200,7 @@ class _AuthCfgCache:
             header = docker.auth.get_config_header(api_client, registry)
             if header is not None:
                 auth_config = json.loads(
-                    base64.urlsafe_b64decode(header), encoding="ascii"
+                    base64.urlsafe_b64decode(header).decode("ascii")
                 )
             else:
                 auth_config = None


### PR DESCRIPTION
In Docker credential cache code, use `.decode` on the `bytes` object instead of deprecated `encoding` kwarg which was removed in py3.9.
