### PR TITLE
fix(docker): exclude .dockerignore from context hash

### DIFF
--- a/rcds/challenge/docker.py
+++ b/rcds/challenge/docker.py
@@ -58,7 +58,10 @@ def get_context_files(root: Path) -> Iterator[Path]:
                     for line in fd
                 ),
             )
-        files = filter(lambda p: not spec.match_file(p.relative_to(root)), files)
+        files = filter(
+            lambda p: not spec.match_file(p.relative_to(root)) and p != dockerignore,
+            files,
+        )
     return filter(lambda p: p.is_file(), files)
 
 

--- a/tests/challenge/test_docker.py
+++ b/tests/challenge/test_docker.py
@@ -26,7 +26,7 @@ class TestGetContextFiles:
         df_root = datadir / "contexts" / "dockerignore"
         assert df_root.is_dir()
         got = {str(p.relative_to(df_root)) for p in docker.get_context_files(df_root)}
-        assert got == {"Dockerfile", ".dockerignore", ".file", "file"}
+        assert got == {"Dockerfile", ".file", "file"}
 
     def test_complex_dockerignore(self, datadir: Path) -> None:
         df_root = datadir / "contexts" / "complex_dockerignore"


### PR DESCRIPTION
Since `.dockerignore` is a means to control what is in the build context, the contents of the file itself should not be included in the context hash. See #117 for more details.

Closes #117
