### PR TITLE
docs: fix typo

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,7 +79,7 @@ the ``docker`` image; you can use ``python`` or any other image with a working
 
         deploy:
           when: manual
-          enviornment:
+          environment:
             name: production
           script:
             - rcds deploy


### PR DESCRIPTION
Fix typo on docs index page