### PR TITLE
fix(test): use match kwarg to check warning messages

### DIFF
--- a/tests/challenge/test_config.py
+++ b/tests/challenge/test_config.py
@@ -110,15 +110,11 @@ def test_nonexistent_flag_file(configloader, test_datadir) -> None:
 
 
 def test_warn_multiline_flag(configloader, test_datadir) -> None:
-    with pytest.warns(RuntimeWarning) as record:
+    with pytest.warns(
+        RuntimeWarning, match=r"^Flag contains multiple lines; is this intended\?$"
+    ):
         cfg, errors = configloader.check_config(test_datadir / "challenge.yml")
     assert errors is None
-    assert len(record) == 1
-    assert isinstance(record[0].message, Warning)
-    assert (
-        str(record[0].message.args[0])
-        == "Flag contains multiple lines; is this intended?"
-    )
 
 
 def test_default_category(configloader, test_datadir) -> None:

--- a/tests/project/test_assets.py
+++ b/tests/project/test_assets.py
@@ -303,11 +303,8 @@ class TestCacheErrorRecovery:
         file1 = ctx._root / "files" / "file1"
         with file1.open("w") as fd:
             fd.write("abcd")
-        with pytest.warns(RuntimeWarning) as record:
+        with pytest.warns(RuntimeWarning, match=r"^Unexpected item found in cache: "):
             ctx.sync(check=True)
-        assert len(record) == 1
-        assert isinstance(record[0].message, Warning)
-        assert "Unexpected item found in cache: " in str(record[0].message.args[0])
         assert not file1.exists()
 
     def test_extra_dir(self, datadir: Path, am_fn: assets.AssetManager) -> None:
@@ -315,11 +312,8 @@ class TestCacheErrorRecovery:
         ctx = asset_manager.create_context("challenge")
         dir1 = ctx._root / "files" / "dir1"
         dir1.mkdir()
-        with pytest.warns(RuntimeWarning) as record:
+        with pytest.warns(RuntimeWarning, match=r"^Unexpected item found in cache: "):
             ctx.sync(check=True)
-        assert len(record) == 1
-        assert isinstance(record[0].message, Warning)
-        assert "Unexpected item found in cache: " in str(record[0].message.args[0])
         assert not dir1.exists()
 
     def test_broken_link(self, datadir: Path, am_fn: assets.AssetManager) -> None:


### PR DESCRIPTION
Use `pytest.warns` `match` to assert that a warning with the correct message was emitted, instead of obtaining a list of warnings emitted matching a type and asserting on that. This should result in better DX since warnings which match the type but not the message are unaffected by the context manager, and bubble up to pytest instead of causing a (relatively opaque) test failure.

The change has the downside of no longer being able to assert that the warning is only emitted once. This is because in Python 3.6 and 3.7, warnings that are normally ignored but raised during a `warns` context manager block still end up in the record, despite being ignored for the purposes of checking whether or not the context manager's assertion succeeded or not. Thus, suppressed warnings will still fail our test if we assert on the length of the record, even though they are otherwise completely ignored (only on these Python versions).

This is probably a pytest bug, however I have not yet had the time to see if it is reported or writing up a report.
