### PR TITLE
fix(k8s): update ingress API to support k8s >v1.21

### DIFF
--- a/rcds/backends/k8s/manifests.py
+++ b/rcds/backends/k8s/manifests.py
@@ -11,7 +11,7 @@ MANIFEST_KINDS = ["Deployment", "Service", "Ingress", "NetworkPolicy"]
 KIND_TO_API_VERISON = {
     "Deployment": "apps/v1",
     "Service": "v1",
-    "Ingress": "networking.k8s.io/v1beta1",
+    "Ingress": "networking.k8s.io/v1",
     "NetworkPolicy": "networking.k8s.io/v1",
 }
 


### PR DESCRIPTION
Update from v1beta1 to v1, as v1beta1 is removed in v1.22 onwards per https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122